### PR TITLE
Fix conflict between Create Fabric's Porting Lib

### DIFF
--- a/src/main/java/io/github/overlordsiii/npcvariety/mixin/spawner/SpawnHelperMixin.java
+++ b/src/main/java/io/github/overlordsiii/npcvariety/mixin/spawner/SpawnHelperMixin.java
@@ -3,30 +3,22 @@ package io.github.overlordsiii.npcvariety.mixin.spawner;
 import io.github.overlordsiii.npcvariety.api.IllagerClothingManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-import net.minecraft.block.BlockState;
-import net.minecraft.entity.EntityData;
-import net.minecraft.entity.SpawnGroup;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.PillagerEntity;
 import net.minecraft.entity.mob.VindicatorEntity;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.SpawnHelper;
-import net.minecraft.world.biome.SpawnSettings;
-import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.gen.StructureAccessor;
-import net.minecraft.world.gen.chunk.ChunkGenerator;
 
 @Mixin(SpawnHelper.class)
 public class SpawnHelperMixin {
 
-	@Inject(method = "spawnEntitiesInChunk(Lnet/minecraft/entity/SpawnGroup;Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/world/chunk/Chunk;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/SpawnHelper$Checker;Lnet/minecraft/world/SpawnHelper$Runner;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/mob/MobEntity;refreshPositionAndAngles(DDDFF)V"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-	private static void addPatchToNaturallySpawningLeaders(SpawnGroup group, ServerWorld world, Chunk chunk, BlockPos pos, SpawnHelper.Checker checker, SpawnHelper.Runner runner, CallbackInfo ci, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, int z, BlockPos.Mutable mutable, int a, int b, int c, int d, int e, SpawnSettings.SpawnEntry entry, EntityData data, int f, int g, int h, double i, double j, PlayerEntity entity, double k, MobEntity mobEntity) {
+	@ModifyArg(
+		method = "spawnEntitiesInChunk(Lnet/minecraft/entity/SpawnGroup;Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/world/chunk/Chunk;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/SpawnHelper$Checker;Lnet/minecraft/world/SpawnHelper$Runner;)V",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/world/SpawnHelper;isValidSpawn(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/mob/MobEntity;D)Z"),
+		index = 1
+	)
+	private static MobEntity addPatchToNaturallySpawningLeaders(MobEntity mobEntity) {
 		if (mobEntity instanceof PillagerEntity pillagerEntity) {
 			if (pillagerEntity instanceof IllagerClothingManager manager && pillagerEntity.isPatrolLeader()) {
 				manager.setEyePatch(true);
@@ -36,6 +28,7 @@ public class SpawnHelperMixin {
 				manager.setEyePatch(true);
 			}
 		}
+		return mobEntity;
 	}
 
 }


### PR DESCRIPTION
Create Fabric version 0.5.0c (for 1.18.2) conflicts with NPC Variety, crashing when entering a world:
```
Caused by: org.spongepowered.asm.mixin.injection.throwables.InjectionError: LVT in net/minecraft/class_1948::method_24930(Lnet/minecraft/class_1311;Lnet/minecraft/class_3218;Lnet/minecraft/class_2791;Lnet/minecraft/class_2338;Lnet/minecraft/class_1948$class_5261;Lnet/minecraft/class_1948$class_5259;)V has incompatible changes at opcode 318 in callback npcvariety.mixins.json:spawner.SpawnHelperMixin from mod npcvariety->@Inject::addPatchtoNaturallySpawningLeaders(Lnet/minecraft/class_1311;Lnet/minecraft/class_3218;Lnet/minecraft/class_2791;Lnet/minecraft/class_2338;Lnet/minecraft/class_1948$class_5261;Lnet/minecraft/class_1948$class_5259;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;ILnet/minecraft/class_2338$class_2339;IIIIILnet/minecraft/class_5483$class_1964;Lnet/minecraft/class_1315;IIIDDLnet/minecraft/class_1657;DLnet/minecraft/class_1308;)V.
 Expected: [Lnet/minecraft/class_5138;, Lnet/minecraft/class_2794;, I, Lnet/minecraft/class_2338$class_2339;, I, I, I, I, I, Lnet/minecraft/class_5483$class_1964;, Lnet/minecraft/class_1315;, I, I, I, D, D, Lnet/minecraft/class_1657;, D, Lnet/minecraft/class_1308;]
    Found: [Lnet/minecraft/class_5138;, Lnet/minecraft/class_2794;, I, Lnet/minecraft/class_2680;, Lnet/minecraft/class_2338$class_2339;, I, I, I, I, I, Lnet/minecraft/class_5483$class_1964;, Lnet/minecraft/class_1315;, I, I, I, D, D, Lnet/minecraft/class_1657;, D]
Available: [Lnet/minecraft/class_5138;, Lnet/minecraft/class_2794;, I, Lnet/minecraft/class_2680;, Lnet/minecraft/class_2338$class_2339;, I, I, I, I, I, Lnet/minecraft/class_5483$class_1964;, Lnet/minecraft/class_1315;, I, I, I, D, D, Lnet/minecraft/class_1657;, D, Lnet/minecraft/class_1308;]
```

This PR fixes this and (and possibly #18 too?)

The conflict is between [`SpawnHelperMixin`](https://github.com/OverlordsIII/NPCVarietyPort/blob/master/src/main/java/io/github/overlordsiii/npcvariety/mixin/spawner/SpawnHelperMixin.java) and Porting Lib, specifically [this Mixin](https://github.com/Fabricators-of-Create/Porting-Lib/blob/9a76362e3f4a5c52110b76f9abdec3c71ec70ac6/base/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/NaturalSpawnerMixin.java#L80-L90) (using Mojmap).

I'm not entirely sure why it conflicts, `@ModifyExpressionValue` is from [Mixin Extras](https://github.com/LlamaLad7/MixinExtras) and seems to work similarly to a `@Redirect`.
Since the target `SpawnHelperMixin` is searching for can't be found after applying the `@ModifyExpressionValue`, the fix is simply to apply `SpawnHelperMixin` first, by increasing its priority (by lowering the number).